### PR TITLE
Add optional checksums for related files

### DIFF
--- a/docs/examples/fmi_ls_ref_manifest_example.xml
+++ b/docs/examples/fmi_ls_ref_manifest_example.xml
@@ -5,10 +5,9 @@
 	xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
 	fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-ref"
 	fmi-ls:fmi-ls-version="1.0.0-alpha.1"
-	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU."
-	checksumRequired="true">
+	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU.">
 
-	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source" checksum="ffe01792c99375508cbe2d1f4c6223f870abef903b0057ec0a445cf081d45b1a" checksumAlgorithm="SHA-256">
+	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source" checksum="ffe01792c99375508cbe2d1f4c6223f870abef903b0057ec0a445cf081d45b1a" checksumAlgorithm="SHA3-256">
 		<Annotations>
 			<Annotation type="com.example.tool">
 				<tool:metadata xmlns:tool="com.example.tool" reviewedBy="alice"/>
@@ -18,16 +17,16 @@
 	<Related type="application/x-ssp-parameter-set" source="baseline-params.ssv" role="parameter" description="Baseline Model Parameters" checksum="6e82821588af4d4d75e8d57ddbca3cca23c79c2b08aec62eb806d438a1107344" checksumAlgorithm="SHA-256">
 		<Label name="variant:baseline" description="Baseline variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="midrange-params.ssv" role="parameter" description="Mid-range Model Parameters" checksum="8955e528070dce74adf46c8146e032e38f98b635454d68775a776aa5ac8f633b" checksumAlgorithm="SHA-256">
+	<Related type="application/x-ssp-parameter-set" source="midrange-params.ssv" role="parameter" description="Mid-range Model Parameters" checksum="8955e528070dce74adf46c8146e032e38f98b635454d68775a776aa5ac8f633b">
 		<Label name="variant:midrange" description="Mid-range variant parameters"/>
 	</Related>
 	<Related type="application/x-ssp-parameter-set" source="highend-params.ssv" role="parameter" description="High-end Model Parameters" checksum="8a22f182b57ccaeec1e5a505954e2e4927fcc996fc19ef762bafe9161e07f88a" checksumAlgorithm="SHA-256">
 		<Label name="variant:highend" description="High-end variant parameters"/>
 	</Related>
 	<Related type="application/x-ssp-parameter-set" source="dynamic-params.ssv" role="parameter" description="Dynamic Model Parameters" checksum="64c8ff700dee2f23de85dcdd584ee3a74b3e8fa0b5c4275f1049119794e68aa8" checksumAlgorithm="SHA-256"/>
-	<Related type="application/x-ma-ls-experiments" source="smoke-tests.exp" role="experiment" description="Smoke Tests of FMU" checksum="11268b2b3121ce05f8162e69d9625794f8909fc9c79c3320c0692be0547ce6e7" checksumAlgorithm="SHA-256">
+	<Related type="application/x-ma-ls-experiments" source="smoke-tests.exp" role="experiment" description="Smoke Tests of FMU">
 		<Label name="simulation-type:SIL" description="Applicable for Software-in-the-Loop simulation"/>
 		<Label name="os:Win64" description="Applicable for Windows 64-bit target"/>
 	</Related>
-	<Related type="application/x-srmd-meta-data" source="metadata/model.srmd" role="meta-data" description="SRMD Meta-Data" checksum="75254b2e76d255d0b1caaa1234008c33f448293c36560e8ed5549e8d6a175ef2" checksumAlgorithm="SHA-256"/>
+	<Related type="application/x-srmd-meta-data" source="metadata/model.srmd" role="meta-data" description="SRMD Meta-Data" checksum="75254b2e76d255d0b1caaa1234008c33f448293c36560e8ed5549e8d6a175ef2"/>
 </fmiReferences>

--- a/docs/examples/fmi_ls_ref_manifest_example.xml
+++ b/docs/examples/fmi_ls_ref_manifest_example.xml
@@ -7,23 +7,23 @@
 	fmi-ls:fmi-ls-version="1.0.0-alpha.1"
 	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU.">
 
-	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source" checksum="ffe01792c99375508cbe2d1f4c6223f870abef903b0057ec0a445cf081d45b1a" checksumAlgorithm="SHA3-256">
+	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source" checksum="ffe01792c99375508cbe2d1f4c6223f870abef903b0057ec0a445cf081d45b1a" checksumType="SHA3-256">
 		<Annotations>
 			<Annotation type="com.example.tool">
 				<tool:metadata xmlns:tool="com.example.tool" reviewedBy="alice"/>
 			</Annotation>
 		</Annotations>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="baseline-params.ssv" role="parameter" description="Baseline Model Parameters" checksum="6e82821588af4d4d75e8d57ddbca3cca23c79c2b08aec62eb806d438a1107344" checksumAlgorithm="SHA-256">
+	<Related type="application/x-ssp-parameter-set" source="baseline-params.ssv" role="parameter" description="Baseline Model Parameters" checksum="6e82821588af4d4d75e8d57ddbca3cca23c79c2b08aec62eb806d438a1107344" checksumType="SHA-256">
 		<Label name="variant:baseline" description="Baseline variant parameters"/>
 	</Related>
 	<Related type="application/x-ssp-parameter-set" source="midrange-params.ssv" role="parameter" description="Mid-range Model Parameters" checksum="8955e528070dce74adf46c8146e032e38f98b635454d68775a776aa5ac8f633b">
 		<Label name="variant:midrange" description="Mid-range variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="highend-params.ssv" role="parameter" description="High-end Model Parameters" checksum="8a22f182b57ccaeec1e5a505954e2e4927fcc996fc19ef762bafe9161e07f88a" checksumAlgorithm="SHA-256">
+	<Related type="application/x-ssp-parameter-set" source="highend-params.ssv" role="parameter" description="High-end Model Parameters" checksum="8a22f182b57ccaeec1e5a505954e2e4927fcc996fc19ef762bafe9161e07f88a" checksumType="SHA-256">
 		<Label name="variant:highend" description="High-end variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="dynamic-params.ssv" role="parameter" description="Dynamic Model Parameters" checksum="64c8ff700dee2f23de85dcdd584ee3a74b3e8fa0b5c4275f1049119794e68aa8" checksumAlgorithm="SHA-256"/>
+	<Related type="application/x-ssp-parameter-set" source="dynamic-params.ssv" role="parameter" description="Dynamic Model Parameters" checksum="64c8ff700dee2f23de85dcdd584ee3a74b3e8fa0b5c4275f1049119794e68aa8" checksumType="SHA-256"/>
 	<Related type="application/x-ma-ls-experiments" source="smoke-tests.exp" role="experiment" description="Smoke Tests of FMU">
 		<Label name="simulation-type:SIL" description="Applicable for Software-in-the-Loop simulation"/>
 		<Label name="os:Win64" description="Applicable for Windows 64-bit target"/>

--- a/docs/examples/fmi_ls_ref_manifest_example.xml
+++ b/docs/examples/fmi_ls_ref_manifest_example.xml
@@ -5,28 +5,29 @@
 	xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
 	fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-ref"
 	fmi-ls:fmi-ls-version="1.0.0-alpha.1"
-	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU.">
-	
-	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source">
+	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU."
+	checksumRequired="true">
+
+	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source" checksum="ffe01792c99375508cbe2d1f4c6223f870abef903b0057ec0a445cf081d45b1a" checksumAlgorithm="SHA-256">
 		<Annotations>
 			<Annotation type="com.example.tool">
 				<tool:metadata xmlns:tool="com.example.tool" reviewedBy="alice"/>
 			</Annotation>
 		</Annotations>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="baseline-params.ssv" role="parameter" description="Baseline Model Parameters">
+	<Related type="application/x-ssp-parameter-set" source="baseline-params.ssv" role="parameter" description="Baseline Model Parameters" checksum="6e82821588af4d4d75e8d57ddbca3cca23c79c2b08aec62eb806d438a1107344" checksumAlgorithm="SHA-256">
 		<Label name="variant:baseline" description="Baseline variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="midrange-params.ssv" role="parameter" description="Mid-range Model Parameters">
+	<Related type="application/x-ssp-parameter-set" source="midrange-params.ssv" role="parameter" description="Mid-range Model Parameters" checksum="8955e528070dce74adf46c8146e032e38f98b635454d68775a776aa5ac8f633b" checksumAlgorithm="SHA-256">
 		<Label name="variant:midrange" description="Mid-range variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="highend-params.ssv" role="parameter" description="High-end Model Parameters">
+	<Related type="application/x-ssp-parameter-set" source="highend-params.ssv" role="parameter" description="High-end Model Parameters" checksum="8a22f182b57ccaeec1e5a505954e2e4927fcc996fc19ef762bafe9161e07f88a" checksumAlgorithm="SHA-256">
 		<Label name="variant:highend" description="High-end variant parameters"/>
 	</Related>
-	<Related type="application/x-ssp-parameter-set" source="dynamic-params.ssv" role="parameter" description="Dynamic Model Parameters"/>
-	<Related type="application/x-ma-ls-experiments" source="smoke-tests.exp" role="experiment" description="Smoke Tests of FMU">
+	<Related type="application/x-ssp-parameter-set" source="dynamic-params.ssv" role="parameter" description="Dynamic Model Parameters" checksum="64c8ff700dee2f23de85dcdd584ee3a74b3e8fa0b5c4275f1049119794e68aa8" checksumAlgorithm="SHA-256"/>
+	<Related type="application/x-ma-ls-experiments" source="smoke-tests.exp" role="experiment" description="Smoke Tests of FMU" checksum="11268b2b3121ce05f8162e69d9625794f8909fc9c79c3320c0692be0547ce6e7" checksumAlgorithm="SHA-256">
 		<Label name="simulation-type:SIL" description="Applicable for Software-in-the-Loop simulation"/>
 		<Label name="os:Win64" description="Applicable for Windows 64-bit target"/>
 	</Related>
-	<Related type="application/x-srmd-meta-data" source="metadata/model.srmd" role="meta-data" description="SRMD Meta-Data"/>
+	<Related type="application/x-srmd-meta-data" source="metadata/model.srmd" role="meta-data" description="SRMD Meta-Data" checksum="75254b2e76d255d0b1caaa1234008c33f448293c36560e8ed5549e8d6a175ef2" checksumAlgorithm="SHA-256"/>
 </fmiReferences>

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -91,6 +91,12 @@ All information about the related files included with the FMU are contained in t
 |`\http://fmi-standard.org/fmi-ls-manifest`
 |`Layered Standard providing information on related files included in an FMU.`
 |String with a brief description of the layered standard that is suitable for display to users.
+
+|`checksumRequired`
+|
+|`true` or `false`
+|Optional boolean attribute, defaulting to `false`, that indicates whether every `<Related>` element in this manifest is expected to provide the `checksum` attribute, e.g. to fulfill fixity requirements for long term archiving.
+This attribute is informative; it is not enforced by the schema, so a consuming application that requires this guarantee has to validate it itself.
 |====
 
 Beside these attributes the root element `fmiReferences` contains the following elements:
@@ -149,6 +155,14 @@ No base requirements on supported URI schemes are given in this layered standard
 
 |`description`
 |Brief description of the related file that is suitable for display to users.
+
+|`checksum`
+|Optional hex-encoded digest of the related file, computed with the algorithm named by `checksumAlgorithm`.
+Allows an importer to verify that the related file has not been modified since the manifest was produced, e.g. to fulfill fixity requirements for long term archiving.
+If the enclosing `fmiReferences` element has `checksumRequired="true"`, every `<Related>` element is expected to provide this attribute.
+
+|`checksumAlgorithm`
+|Algorithm used to compute the `checksum` attribute. One of `SHA-256`, `SHA-384`, or `SHA-512`, defaulting to `SHA-256`. Ignored if `checksum` is absent.
 |====
 
 The `role` attribute is used to indicate the purpose of the related file.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -91,12 +91,6 @@ All information about the related files included with the FMU are contained in t
 |`\http://fmi-standard.org/fmi-ls-manifest`
 |`Layered Standard providing information on related files included in an FMU.`
 |String with a brief description of the layered standard that is suitable for display to users.
-
-|`checksumRequired`
-|
-|`true` or `false`
-|Optional boolean attribute, defaulting to `false`, that indicates whether every `<Related>` element in this manifest is expected to provide the `checksum` attribute, e.g. to fulfill fixity requirements for long term archiving.
-This attribute is informative; it is not enforced by the schema, so a consuming application that requires this guarantee has to validate it itself.
 |====
 
 Beside these attributes the root element `fmiReferences` contains the following elements:
@@ -157,12 +151,14 @@ No base requirements on supported URI schemes are given in this layered standard
 |Brief description of the related file that is suitable for display to users.
 
 |`checksum`
-|Optional hex-encoded digest of the related file, computed with the algorithm named by `checksumAlgorithm`.
-Allows an importer to verify that the related file has not been modified since the manifest was produced, e.g. to fulfill fixity requirements for long term archiving.
-If the enclosing `fmiReferences` element has `checksumRequired="true"`, every `<Related>` element is expected to provide this attribute.
+|This optional attribute provides a hex-encoded digest of the resource referenced by source, allowing a consumer to verify that the resource has not been modified since the manifest was produced, to detect accidental changes or misidentification.
+The digest is calculated using the algorithm indicated by the `checksumType` attribute.
 
-|`checksumAlgorithm`
-|Algorithm used to compute the `checksum` attribute. One of `SHA-256`, `SHA-384`, or `SHA-512`, defaulting to `SHA-256`. Ignored if `checksum` is absent.
+|`checksumType`
+|This optional attribute gives the algorithm for the calculation of the `checksum` attribute.
+It defaults to SHA3-256 if this attribute is omitted.
+Must be one of SHA3-224, SHA3-256, SHA3-384, SHA3-512 (as specified in FIPS 202), or - for legacy reasons - one of SHA-224, SHA-256, SHA-384, SHA-512 (as specified in FIPS 180-4, SHA-2 family).
+In future other digest algorithms might be supported.
 |====
 
 The `role` attribute is used to indicate the purpose of the related file.

--- a/schema/fmi3LayeredStandardReferenceManifest.xsd
+++ b/schema/fmi3LayeredStandardReferenceManifest.xsd
@@ -44,6 +44,16 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <xs:attribute ref="fmi-ls:fmi-ls-name" use="required" fixed="org.fmi-standard.fmi-ls-ref"/>
             <xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
             <xs:attribute ref="fmi-ls:fmi-ls-description" use="required" fixed="Layered Standard providing information on related files included in an FMU."/>
+            <xs:attribute name="checksumRequired" type="xs:boolean" use="optional" default="false">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        If set to true, every Related element in this manifest is expected to
+                        provide the checksum attribute, e.g. to fulfill fixity requirements for
+                        long term archiving. This attribute is not enforced by the schema; a
+                        consuming application that requires this guarantee shall validate it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     
@@ -82,6 +92,38 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="description" type="xs:string"/>
+        <xs:attribute name="checksum" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This optional attribute provides a hex-encoded digest of the resource
+                    referenced by source, computed with the algorithm named by
+                    checksumAlgorithm. It allows a consumer to verify that the referenced
+                    resource has not been modified since the manifest was produced, e.g. to
+                    fulfill fixity requirements for long term archiving.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="[0-9a-fA-F]+"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="checksumAlgorithm" use="optional" default="SHA-256">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the algorithm used to compute the checksum
+                    attribute. Defaults to SHA-256 if checksum is present and this attribute
+                    is omitted. Ignored if checksum is absent.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="SHA-256"/>
+                    <xs:enumeration value="SHA-384"/>
+                    <xs:enumeration value="SHA-512"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="TLabel">

--- a/schema/fmi3LayeredStandardReferenceManifest.xsd
+++ b/schema/fmi3LayeredStandardReferenceManifest.xsd
@@ -44,16 +44,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <xs:attribute ref="fmi-ls:fmi-ls-name" use="required" fixed="org.fmi-standard.fmi-ls-ref"/>
             <xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
             <xs:attribute ref="fmi-ls:fmi-ls-description" use="required" fixed="Layered Standard providing information on related files included in an FMU."/>
-            <xs:attribute name="checksumRequired" type="xs:boolean" use="optional" default="false">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        If set to true, every Related element in this manifest is expected to
-                        provide the checksum attribute, e.g. to fulfill fixity requirements for
-                        long term archiving. This attribute is not enforced by the schema; a
-                        consuming application that requires this guarantee shall validate it.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
         </xs:complexType>
     </xs:element>
     
@@ -92,32 +82,36 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="description" type="xs:string"/>
-        <xs:attribute name="checksum" use="optional">
+        <xs:attribute name="checksum" type="xs:hexBinary">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
                     This optional attribute provides a hex-encoded digest of the resource
-                    referenced by source, computed with the algorithm named by
-                    checksumAlgorithm. It allows a consumer to verify that the referenced
-                    resource has not been modified since the manifest was produced, e.g. to
-                    fulfill fixity requirements for long term archiving.
+                    referenced by source, allowing a consumer to verify that the resource
+                    has not been modified since the manifest was produced, to detect
+                    accidental changes or misidentification. The digest is calculated using
+                    the algorithm indicated by the checksumType attribute.
                 </xs:documentation>
             </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:pattern value="[0-9a-fA-F]+"/>
-                </xs:restriction>
-            </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="checksumAlgorithm" use="optional" default="SHA-256">
+        <xs:attribute name="checksumType" type="xs:string" default="SHA3-256">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
-                    This attribute specifies the algorithm used to compute the checksum
-                    attribute. Defaults to SHA-256 if checksum is present and this attribute
-                    is omitted. Ignored if checksum is absent.
+                    This optional attribute gives the algorithm for the calculation of the
+                    `checksum` attribute. It defaults to SHA3-256 if this attribute is omitted.
+                    MUST be one of SHA3-224, SHA3-256, SHA3-384, SHA3-512 (as specified in FIPS
+                    202), or - for legacy reasons - one of SHA-224, SHA-256, SHA-384, SHA-512
+                    (as specified in FIPS 180-4, SHA-2 family).
+
+                    In future other digest algorithms might be supported.
                 </xs:documentation>
             </xs:annotation>
             <xs:simpleType>
                 <xs:restriction base="xs:string">
+                    <xs:enumeration value="SHA3-224"/>
+                    <xs:enumeration value="SHA3-256"/>
+                    <xs:enumeration value="SHA3-384"/>
+                    <xs:enumeration value="SHA3-512"/>
+                    <xs:enumeration value="SHA-224"/>
                     <xs:enumeration value="SHA-256"/>
                     <xs:enumeration value="SHA-384"/>
                     <xs:enumeration value="SHA-512"/>

--- a/schema/fmi3LayeredStandardReferenceManifest.xsd
+++ b/schema/fmi3LayeredStandardReferenceManifest.xsd
@@ -93,7 +93,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="checksumType" type="xs:string" default="SHA3-256">
+        <xs:attribute name="checksumType" default="SHA3-256">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
                     This optional attribute gives the algorithm for the calculation of the


### PR DESCRIPTION
## Summary
- Adds `checksumRequired` (boolean, default `false`) on the `fmiReferences` root element as a manifest-level toggle indicating whether every `Related` element is expected to carry a checksum.
- Adds optional `checksum` (hex-encoded digest) and `checksumAlgorithm` (`SHA-256` | `SHA-384` | `SHA-512`, default `SHA-256`) attributes on `Related`, so each linked file can carry an integrity hash.
- Updates `docs/index.adoc` attribute tables and the example manifest (`docs/examples/fmi_ls_ref_manifest_example.xml`) accordingly.

Per the discussion in the issue, this stays optional, minimal, defaults to not-required, and stays with XSD 1.0 — `checksumRequired` is documented as an informative constraint (consumers that need the guarantee validate it themselves) rather than schema-enforced, since XSD 1.0 can't express a cross-attribute conditional requirement without `xs:assert` (XSD 1.1).

Closes #35

## Test plan
- [x] Confirmed the modified `.xsd` is well-formed XML
- [x] Confirmed the pre-existing `xs:import` validation warning from `lxml` is unchanged from `main` (not introduced by this change)
- [x] Updated example manifest carries 64-char hex `checksum` values for all `Related` entries and validates against the new attribute pattern