### PR TITLE
Optionally forbid absolute source URIs

### DIFF
--- a/docs/examples/fmi_ls_ref_manifest_example.xml
+++ b/docs/examples/fmi_ls_ref_manifest_example.xml
@@ -5,8 +5,9 @@
 	xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
 	fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-ref"
 	fmi-ls:fmi-ls-version="1.0.0-alpha.1"
-	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU.">
-	
+	fmi-ls:fmi-ls-description="Layered Standard providing information on related files included in an FMU."
+	absoluteSourceForbidden="true">
+
 	<Related type="text/modelica" source="modelica/mymodel.mo" role="model" description="Modelica Model Source">
 		<Annotations>
 			<Annotation type="com.example.tool">

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -91,6 +91,12 @@ All information about the related files included with the FMU are contained in t
 |`\http://fmi-standard.org/fmi-ls-manifest`
 |`Layered Standard providing information on related files included in an FMU.`
 |String with a brief description of the layered standard that is suitable for display to users.
+
+|`absoluteSourceForbidden`
+|
+|`true` or `false`
+|Optional boolean attribute, defaulting to `false`, that indicates whether every `<Related>` element in this manifest is expected to use a `source` URI without a scheme component (i.e. not an absolute URI), e.g. to ensure the manifest remains resolvable over long time horizons for archiving purposes.
+This attribute is informative; it is not enforced by the schema, so a consuming application that requires this guarantee has to validate it itself.
 |====
 
 Beside these attributes the root element `fmiReferences` contains the following elements:
@@ -143,6 +149,7 @@ This allows the referencing of related files included in other places of the FMU
 If absolute URIs are used, it is left to the importer to decide how to handle these URIs, e.g., whether to try to download the file from the given URI, or to ignore the related file, or handle it in some other way.
 Similarly the set of allowed URI schemes is dependent on the importer.
 No base requirements on supported URI schemes are given in this layered standard, apart from the fact that relative URIs pointing to files inside the FMU archive are always supported.
+A manifest producer that wants to guarantee no absolute URIs are used, e.g. for long term archiving purposes, can indicate this using the `absoluteSourceForbidden` attribute of the `fmiReferences` root element.
 
 |`role`
 |Role of the related file, e.g., `model`, `requirement`, `specification`, `parameter`, `experiment`, etc.

--- a/schema/fmi3LayeredStandardReferenceManifest.xsd
+++ b/schema/fmi3LayeredStandardReferenceManifest.xsd
@@ -44,6 +44,20 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <xs:attribute ref="fmi-ls:fmi-ls-name" use="required" fixed="org.fmi-standard.fmi-ls-ref"/>
             <xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
             <xs:attribute ref="fmi-ls:fmi-ls-description" use="required" fixed="Layered Standard providing information on related files included in an FMU."/>
+            <xs:attribute name="absoluteSourceForbidden" type="xs:boolean" use="optional" default="false">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        If set to true, every Related element in this manifest is expected to
+                        use a source URI without a scheme component (i.e. not an absolute URI
+                        per RFC 3986, such as http://... or file:///...), e.g. to ensure the
+                        manifest remains resolvable over long time horizons for archiving
+                        purposes. Root-relative (/foo/bar) and scheme-relative (//host/path)
+                        forms are not considered absolute for purposes of this attribute. This
+                        attribute is not enforced by the schema; a consuming application that
+                        requires this guarantee shall validate it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     


### PR DESCRIPTION
## Summary
- Adds `absoluteSourceForbidden` (boolean, default `false`) on the `fmiReferences` root element: an opt-in flag a manifest producer can set to declare that no `Related/@source` uses an absolute URI (i.e. a URI with a scheme component per RFC 3986, such as `http://` or `file:///`), for long term archiving purposes where absolute URIs can't be relied upon.
- "Absolute" is scoped to scheme URIs only — root-relative (`/foo/bar`) and scheme-relative (`//host/path`) forms are unaffected.
- Like `checksumRequired` (#36), this is documented as an informative constraint rather than schema-enforced: XSD 1.0 can't express "if root/@flag=true then Related/@source must not have a scheme" without `xs:assert` (XSD 1.1), so per the issue's request to start with the simplest possible solution, this stays XSD 1.0 and leaves enforcement to consuming applications.
- Updates `docs/index.adoc` and the example manifest accordingly. Purely additive — no change to `TRelated`/`source`'s type.

Closes #37

## Test plan
- [x] Confirmed the modified `.xsd` and example manifest are well-formed XML
- [x] Confirmed the pre-existing `xs:import` validation warning from `lxml` is unchanged (not introduced by this change)
- [x] Confirmed the diff is additive-only