### PR TITLE
Fix invalid xs:import of fmi3Annotation.xsd

### DIFF
--- a/schema/fmi3LayeredStandardReferenceManifest.xsd
+++ b/schema/fmi3LayeredStandardReferenceManifest.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest" elementFormDefault="qualified" attributeFormDefault="qualified">
     <xs:import namespace="http://fmi-standard.org/fmi-ls-manifest" schemaLocation="https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3LayeredStandardManifest.xsd"/>
-    <xs:import schemaLocation="https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3Annotation.xsd"/>
+    <xs:include schemaLocation="https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3Annotation.xsd"/>
     <xs:annotation>
         <xs:documentation>
 Copyright(c) 2023-2025 Modelica Association Project "FMI".


### PR DESCRIPTION
## Summary
`fmi3LayeredStandardReferenceManifest.xsd` pulled in `fmi3Annotation.xsd` via `xs:import` with no `namespace` attribute:

```xml
<xs:import schemaLocation="https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3Annotation.xsd"/>
```

Neither this schema nor `fmi3Annotation.xsd` declares a `targetNamespace` — both are in "no namespace". Per XSD 1.0 (§4.2.3), `xs:import` is for pulling in components from a *different* namespace than the importing schema; merging components from a schema with the same (or absent) target namespace is what `xs:include` is for. `xs:import` without a `namespace` attribute, used by a schema that itself has no target namespace, is not spec-conformant.

Lenient validators (libxml2/`xmllint`, many IDEs) tolerate this, which is presumably why it went unnoticed, but strict tooling rejects the schema outright — e.g. the Python `xmlschema` library fails to even load it:

```
XMLSchemaParseError: if the 'namespace' attribute is not present on the import statement then the imported schema must have a 'targetNamespace'
```

**Fix**: `xs:import` → `xs:include` for this one line (`xs:include` takes no `namespace` attribute). The other `xs:import` in this file, for `fmi3LayeredStandardManifest.xsd` (which does declare `targetNamespace="http://fmi-standard.org/fmi-ls-manifest"`), is correct and untouched.

(The same issue exists in the sibling `ma-hs-experiments` schema, fixed separately in modelica/ma-hs-experiments#8.)

Closes #39

## Test plan
- [x] Confirmed the schema and example manifest validate successfully with the strict Python `xmlschema` library after the change (previously failed to even load the schema)